### PR TITLE
Remove extra dot from packed manifest file

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,7 @@ module.exports = async (env, options)  => {
           from: "./src/taskpane/taskpane.css"
         },
         {
-          to: "[name]." + buildType + ".[ext]",
+          to: "[name]." + buildType + "[ext]",
           from: "manifest*.xml",
           transform(content) {
             if (dev) {


### PR DESCRIPTION
The [ext] pattern already brings in a dot. Current behavior as seen from webpack build output:
```
asset manifest.dev..xml 4.12 KiB [emitted] [from: manifest.xml] [copied]
```