### PR TITLE
Move to FluentUI v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -287,68 +287,260 @@
       }
     },
     "@fluentui/date-time-utilities": {
-      "version": "7.9.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-7.9.1.tgz",
-      "integrity": "sha512-o8iU1VIY+QsqVRWARKiky29fh4KR1xaKSgMClXIi65qkt8EDDhjmlzL0KVDEoDA2GWukwb/1PpaVCWDg4v3cUQ==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/date-time-utilities/-/date-time-utilities-8.1.1.tgz",
+      "integrity": "sha512-mAgirydYtUzD/8i1KwHtZ8Ro56QG4MQfA09g+vdadotw8g/z5S994cSB+aKtQQx1IDMx8MSl2L2TqDTpYaTQyw==",
       "requires": {
-        "@uifabric/set-version": "^7.0.24",
-        "tslib": "^1.10.0"
+        "@fluentui/set-version": "^8.1.1",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@fluentui/dom-utilities": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-1.1.2.tgz",
-      "integrity": "sha512-XqPS7l3YoMwxdNlaYF6S2Mp0K3FmVIOIy2K3YkMc+eRxu9wFK6emr2Q/3rBhtG5u/On37NExRT7/5CTLnoi9gw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/dom-utilities/-/dom-utilities-2.1.1.tgz",
+      "integrity": "sha512-3y7MdWzXp6wYEy2j3GMAx+epbpTdPQfoiASsDgBaT2axpCyQ0UlTfPdPOrSXiPUMgvUeXkYmgyLvsqpu/zEqHw==",
       "requires": {
-        "@uifabric/set-version": "^7.0.24",
-        "tslib": "^1.10.0"
+        "@fluentui/set-version": "^8.1.1",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@fluentui/font-icons-mdl2": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/font-icons-mdl2/-/font-icons-mdl2-8.1.1.tgz",
+      "integrity": "sha512-u448uer/0ai9pVYQcKjomNq+dRiF9iql1LlwrcpMYZ4YdTdj+WFD4IAr5L4BTZ++ccUR9WTIWVHyvDSnealxtA==",
+      "requires": {
+        "@fluentui/set-version": "^8.1.1",
+        "@fluentui/style-utilities": "^8.1.1",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@fluentui/foundation-legacy": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/foundation-legacy/-/foundation-legacy-8.1.1.tgz",
+      "integrity": "sha512-I2EWq8K1QmD8+ktL0+znUEtLPExUYfiekWdYRGr/qrg691BObkUlZCfbnjPGVUYkzxRvD7ns/mR8v1BXMMZazQ==",
+      "requires": {
+        "@fluentui/merge-styles": "^8.1.1",
+        "@fluentui/set-version": "^8.1.1",
+        "@fluentui/style-utilities": "^8.1.1",
+        "@fluentui/utilities": "^8.1.1",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@fluentui/keyboard-key": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.2.16.tgz",
-      "integrity": "sha512-T4eQ0uqhbTScsoXVx10Tlp0C2RgNdAzlbe52qJ0Tn288/Nuztda5Z/aTCRd5Rp5MRYBycjAf4iNot6ZHAP864g==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/keyboard-key/-/keyboard-key-0.3.1.tgz",
+      "integrity": "sha512-2Mf5fSvXLkD01AM2Sr7tEgz4HiB+HkYrBUpGzn7U7yOwKVzavgATRrI0xIaZkoWKUhjtcl/iY1YtOsMvyfJfBA==",
       "requires": {
-        "tslib": "^1.10.0"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@fluentui/merge-styles": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/merge-styles/-/merge-styles-8.1.1.tgz",
+      "integrity": "sha512-RwBx8QyN3AC0JeDz/mtLAcDr3xKCaeyF4YEeQ21isr1fZTgKQ5MPJ2LBJnT6Vbl0H041gtoLpJGnQczTd2CAmg==",
+      "requires": {
+        "@fluentui/set-version": "^8.1.1",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@fluentui/react": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@fluentui/react/-/react-8.16.0.tgz",
+      "integrity": "sha512-ATRelZqopsjN5s6diaGeo251AeCaR2/0d0JS3C6P8cF0ZpNYYQGBSMq73Xd/oV2PMXoMVSoJvowl9RMlTa0TTg==",
+      "requires": {
+        "@fluentui/date-time-utilities": "^8.1.1",
+        "@fluentui/font-icons-mdl2": "^8.1.1",
+        "@fluentui/foundation-legacy": "^8.1.1",
+        "@fluentui/merge-styles": "^8.1.1",
+        "@fluentui/react-focus": "^8.1.2",
+        "@fluentui/react-hooks": "^8.2.1",
+        "@fluentui/react-window-provider": "^2.1.1",
+        "@fluentui/set-version": "^8.1.1",
+        "@fluentui/style-utilities": "^8.1.1",
+        "@fluentui/theme": "^2.1.1",
+        "@fluentui/utilities": "^8.1.1",
+        "@microsoft/load-themed-styles": "^1.10.26",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@fluentui/react-focus": {
-      "version": "7.17.6",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.17.6.tgz",
-      "integrity": "sha512-JkLWNDe567lhvbnIhbYv9nUWYDIVN06utc3krs0UZBI+A0YZtQmftBtY0ghXo4PSjgozZocdu9sYkkgZOgyRLg==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-8.1.2.tgz",
+      "integrity": "sha512-w+M4Ki+XKNlaFeYcwxs2gyH+RyHN2tmbzfSMPJ8k6VgWssOA2mAAKfV0tGHxRBRMJEeMrIRIzQ7axicEYA3MSA==",
       "requires": {
-        "@fluentui/keyboard-key": "^0.2.12",
-        "@uifabric/merge-styles": "^7.19.2",
-        "@uifabric/set-version": "^7.0.24",
-        "@uifabric/styling": "^7.19.0",
-        "@uifabric/utilities": "^7.33.5",
-        "tslib": "^1.10.0"
+        "@fluentui/keyboard-key": "^0.3.1",
+        "@fluentui/merge-styles": "^8.1.1",
+        "@fluentui/set-version": "^8.1.1",
+        "@fluentui/style-utilities": "^8.1.1",
+        "@fluentui/utilities": "^8.1.1",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@fluentui/react-hooks": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-hooks/-/react-hooks-8.2.1.tgz",
+      "integrity": "sha512-6aZYA7cN3ahu3pyePojwfP+m+/PoYGkyO/tLQ1RlkbpRbbIXiIzKWV3pMezn3knU1XFcUSA29PJtlKbrmknLnw==",
+      "requires": {
+        "@fluentui/react-window-provider": "^2.1.1",
+        "@fluentui/set-version": "^8.1.1",
+        "@fluentui/utilities": "^8.1.1",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@fluentui/react-window-provider": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-1.0.2.tgz",
-      "integrity": "sha512-fGSgL3Vp/+6t1Ysfz21FWZmqsU+iFVxOigvHnm5uKVyyRPwtaabv/F6kQ2y5isLMI2YmJaUd2i0cDJKu8ggrvw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-2.1.1.tgz",
+      "integrity": "sha512-Ue2okXG7eUInNnbmxAMkKY7reMlWwlmsY46Mlc9rsAWFHCvSo0wm0oRzFWtKXulnX1Dn+dtR1EhXhKhDktXfag==",
       "requires": {
-        "@uifabric/set-version": "^7.0.24",
-        "tslib": "^1.10.0"
+        "@fluentui/set-version": "^8.1.1",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@fluentui/set-version": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/set-version/-/set-version-8.1.1.tgz",
+      "integrity": "sha512-/3n4imK0qJxs7/c+wNRgq2KqezDWi1quwK6cSdaxuHHwi3VBG3mWLWZj9cejnByY80NvUhj0fNlpoq/cE3Pa6A==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@fluentui/style-utilities": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/style-utilities/-/style-utilities-8.1.1.tgz",
+      "integrity": "sha512-0Ca5ZmODiOlPPlMhgAVO57mLZtkG7/0PMZ/bEPvs6Brz37yuEenMyBlOdklyEM/qpZxPyjmDHZf0BwX573nA5g==",
+      "requires": {
+        "@fluentui/merge-styles": "^8.1.1",
+        "@fluentui/set-version": "^8.1.1",
+        "@fluentui/theme": "^2.1.1",
+        "@fluentui/utilities": "^8.1.1",
+        "@microsoft/load-themed-styles": "^1.10.26",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@fluentui/theme": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-1.7.4.tgz",
-      "integrity": "sha512-o4eo7lstLxxXl1g2RR9yz18Yt8yjQO/LbQuZjsiAfv/4Bf0CRnb+3j1F7gxIdBWAchKj9gzaMpIFijfI98pvYQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-2.1.1.tgz",
+      "integrity": "sha512-OZyRsGIVnaxwn9Ns1Dy2p3b6p6umspVZ25inOGaB8oo+ruv6v+QxkawngpXzceUdhmZOSohw71AkQ2wlkDz/sw==",
       "requires": {
-        "@uifabric/merge-styles": "^7.19.2",
-        "@uifabric/set-version": "^7.0.24",
-        "@uifabric/utilities": "^7.33.5",
-        "tslib": "^1.10.0"
+        "@fluentui/merge-styles": "^8.1.1",
+        "@fluentui/set-version": "^8.1.1",
+        "@fluentui/utilities": "^8.1.1",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
+      }
+    },
+    "@fluentui/utilities": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@fluentui/utilities/-/utilities-8.1.1.tgz",
+      "integrity": "sha512-RVIl6+YM8KbfUl0mYhDg9uRbfH/Czz+R8sQHBX4JIaNoMa7N6U0Uvp1fcGzBqB/Brv5lPC8usySrIf5kiQnfBg==",
+      "requires": {
+        "@fluentui/dom-utilities": "^2.1.1",
+        "@fluentui/merge-styles": "^8.1.1",
+        "@fluentui/set-version": "^8.1.1",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+          "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+        }
       }
     },
     "@microsoft/load-themed-styles": {
-      "version": "1.10.155",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.155.tgz",
-      "integrity": "sha512-jXcfI934j2I6lFdja5fuz8BCAXX/W+bHo0eXNAnE1qQB1UPf31fvXT2XeqazqZP45G/XqwfrUu0zeflSadx6WQ=="
+      "version": "1.10.174",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.10.174.tgz",
+      "integrity": "sha512-O0ERVgeTrpzCzCLHOTZZDSg0K3FKdWRdBpFjs+X5wS21Jg21QqrA4T9FhCheilEcrF4Qmf41gBtgZ/16JNSWIA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -814,81 +1006,6 @@
           "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
           "dev": true
         }
-      }
-    },
-    "@uifabric/foundation": {
-      "version": "7.9.26",
-      "resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.9.26.tgz",
-      "integrity": "sha512-1FLTb+jlH/Tuel2L9wT/zLl5ZW6W4Lbjrs5VUVjv81vWxzznvPnTf8+Ew0qkzaH7xDuMNMl7okswhV0IfJyheg==",
-      "requires": {
-        "@uifabric/merge-styles": "^7.19.2",
-        "@uifabric/set-version": "^7.0.24",
-        "@uifabric/styling": "^7.19.0",
-        "@uifabric/utilities": "^7.33.5",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@uifabric/icons": {
-      "version": "7.5.23",
-      "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.5.23.tgz",
-      "integrity": "sha512-eIvUbH0EWgFgdfgFfINgqS2ZVZTyJ/9n5nR4bmcyAe75wsKxm4ser4WIT9IvaBF6+HFVfjUF/v6+VMD7y2LBng==",
-      "requires": {
-        "@uifabric/set-version": "^7.0.24",
-        "@uifabric/styling": "^7.19.0",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@uifabric/merge-styles": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-7.19.2.tgz",
-      "integrity": "sha512-kTlhwglDqwVgIaJq+0yXgzi65plGhmFcPrfme/rXUGMJZoU+qlGT5jXj5d3kuI59p6VB8jWEg9DAxHozhYeu0g==",
-      "requires": {
-        "@uifabric/set-version": "^7.0.24",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@uifabric/react-hooks": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.14.0.tgz",
-      "integrity": "sha512-Ndu/DEKHF4gFXEZa2AGgSkdWaj+njVrsSyXbkWRh2UZReFWnH1LMko9p/ZCwk1i9kAd5CUmyIfURUzIEya9YCg==",
-      "requires": {
-        "@fluentui/react-window-provider": "^1.0.2",
-        "@uifabric/set-version": "^7.0.24",
-        "@uifabric/utilities": "^7.33.5",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@uifabric/set-version": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-7.0.24.tgz",
-      "integrity": "sha512-t0Pt21dRqdC707/ConVJC0WvcQ/KF7tKLU8AZY7YdjgJpMHi1c0C427DB4jfUY19I92f60LOQyhJ4efH+KpFEg==",
-      "requires": {
-        "tslib": "^1.10.0"
-      }
-    },
-    "@uifabric/styling": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.19.0.tgz",
-      "integrity": "sha512-fXComDtGV7dHF4rP4cLHwI6fC+1f/nvPavpMBz4IQdySwixta9TVMKbzt0OA6i0mJztqZCVAd27F/sl9R/JmcQ==",
-      "requires": {
-        "@fluentui/theme": "^1.7.4",
-        "@microsoft/load-themed-styles": "^1.10.26",
-        "@uifabric/merge-styles": "^7.19.2",
-        "@uifabric/set-version": "^7.0.24",
-        "@uifabric/utilities": "^7.33.5",
-        "tslib": "^1.10.0"
-      }
-    },
-    "@uifabric/utilities": {
-      "version": "7.33.5",
-      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.33.5.tgz",
-      "integrity": "sha512-I+Oi0deD/xltSluFY8l2EVd/J4mvOaMljxKO2knSD9/KoGDlo/o5GN4gbnVo8nIt76HWHLAk3KtlJKJm6BhbIQ==",
-      "requires": {
-        "@fluentui/dom-utilities": "^1.1.2",
-        "@uifabric/merge-styles": "^7.19.2",
-        "@uifabric/set-version": "^7.0.24",
-        "prop-types": "^15.7.2",
-        "tslib": "^1.10.0"
       }
     },
     "@ungap/promise-all-settled": {
@@ -7157,26 +7274,6 @@
         }
       }
     },
-    "office-ui-fabric-react": {
-      "version": "7.165.1",
-      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.165.1.tgz",
-      "integrity": "sha512-a8H0KGwhfEps7v0Ia+kU9kQyRtj3qVMWbkDmMhZ2iTnPXcMs6gF1X+1x3xuMQblJXpp/fqyCLpuU1DUSOMbmhw==",
-      "requires": {
-        "@fluentui/date-time-utilities": "^7.9.1",
-        "@fluentui/react-focus": "^7.17.6",
-        "@fluentui/react-window-provider": "^1.0.2",
-        "@microsoft/load-themed-styles": "^1.10.26",
-        "@uifabric/foundation": "^7.9.26",
-        "@uifabric/icons": "^7.5.23",
-        "@uifabric/merge-styles": "^7.19.2",
-        "@uifabric/react-hooks": "^7.14.0",
-        "@uifabric/set-version": "^7.0.24",
-        "@uifabric/styling": "^7.19.0",
-        "@uifabric/utilities": "^7.33.5",
-        "prop-types": "^15.7.2",
-        "tslib": "^1.10.0"
-      }
-    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -9622,7 +9719,8 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "watch": "webpack --mode development --watch"
   },
   "dependencies": {
+    "@fluentui/react": "^8.16.0",
     "core-js": "^3.9.1",
     "es6-promise": "^4.2.8",
-    "office-ui-fabric-react": "^7.10.0",
     "react": "^16.8.2",
     "react-dom": "^16.8.2",
     "regenerator-runtime": "^0.13.7"

--- a/src/taskpane/components/App.tsx
+++ b/src/taskpane/components/App.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Button, ButtonType } from "office-ui-fabric-react";
+import { DefaultButton } from "@fluentui/react";
 import Header from "./Header";
 import HeroList, { HeroListItem } from "./HeroList";
 import Progress from "./Progress";
@@ -92,14 +92,9 @@ export default class App extends React.Component<AppProps, AppState> {
           <p className="ms-font-l">
             Modify the source files, then click <b>Run</b>.
           </p>
-          <Button
-            className="ms-welcome__action"
-            buttonType={ButtonType.hero}
-            iconProps={{ iconName: "ChevronRight" }}
-            onClick={this.click}
-          >
+          <DefaultButton className="ms-welcome__action" iconProps={{ iconName: "ChevronRight" }} onClick={this.click}>
             Run
-          </Button>
+          </DefaultButton>
         </HeroList>
       </div>
     );

--- a/src/taskpane/components/Excel.App.tsx
+++ b/src/taskpane/components/Excel.App.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Button, ButtonType } from "office-ui-fabric-react";
+import { DefaultButton } from "@fluentui/react";
 import Header from "./Header";
 import HeroList, { HeroListItem } from "./HeroList";
 import Progress from "./Progress";
@@ -83,14 +83,9 @@ export default class App extends React.Component<AppProps, AppState> {
           <p className="ms-font-l">
             Modify the source files, then click <b>Run</b>.
           </p>
-          <Button
-            className="ms-welcome__action"
-            buttonType={ButtonType.hero}
-            iconProps={{ iconName: "ChevronRight" }}
-            onClick={this.click}
-          >
+          <DefaultButton className="ms-welcome__action" iconProps={{ iconName: "ChevronRight" }} onClick={this.click}>
             Run
-          </Button>
+          </DefaultButton>
         </HeroList>
       </div>
     );

--- a/src/taskpane/components/OneNote.App.tsx
+++ b/src/taskpane/components/OneNote.App.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Button, ButtonType } from "office-ui-fabric-react";
+import { DefaultButton } from "@fluentui/react";
 import Header from "./Header";
 import HeroList, { HeroListItem } from "./HeroList";
 import Progress from "./Progress";
@@ -66,14 +66,9 @@ export default class App extends React.Component<AppProps, AppState> {
           <p className="ms-font-l">
             Modify the source files, then click <b>Run</b>.
           </p>
-          <Button
-            className="ms-welcome__action"
-            buttonType={ButtonType.hero}
-            iconProps={{ iconName: "ChevronRight" }}
-            onClick={this.click}
-          >
+          <DefaultButton className="ms-welcome__action" iconProps={{ iconName: "ChevronRight" }} onClick={this.click}>
             Run
-          </Button>
+          </DefaultButton>
         </HeroList>
       </div>
     );

--- a/src/taskpane/components/Outlook.App.tsx
+++ b/src/taskpane/components/Outlook.App.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Button, ButtonType } from "office-ui-fabric-react";
+import { DefaultButton } from "@fluentui/react";
 import Header from "./Header";
 import HeroList, { HeroListItem } from "./HeroList";
 import Progress from "./Progress";
@@ -66,14 +66,9 @@ export default class App extends React.Component<AppProps, AppState> {
           <p className="ms-font-l">
             Modify the source files, then click <b>Run</b>.
           </p>
-          <Button
-            className="ms-welcome__action"
-            buttonType={ButtonType.hero}
-            iconProps={{ iconName: "ChevronRight" }}
-            onClick={this.click}
-          >
+          <DefaultButton className="ms-welcome__action" iconProps={{ iconName: "ChevronRight" }} onClick={this.click}>
             Run
-          </Button>
+          </DefaultButton>
         </HeroList>
       </div>
     );

--- a/src/taskpane/components/PowerPoint.App.tsx
+++ b/src/taskpane/components/PowerPoint.App.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Button, ButtonType } from "office-ui-fabric-react";
+import { DefaultButton } from "@fluentui/react";
 import Header from "./Header";
 import HeroList, { HeroListItem } from "./HeroList";
 import Progress from "./Progress";
@@ -78,14 +78,9 @@ export default class App extends React.Component<AppProps, AppState> {
           <p className="ms-font-l">
             Modify the source files, then click <b>Run</b>.
           </p>
-          <Button
-            className="ms-welcome__action"
-            buttonType={ButtonType.hero}
-            iconProps={{ iconName: "ChevronRight" }}
-            onClick={this.click}
-          >
+          <DefaultButton className="ms-welcome__action" iconProps={{ iconName: "ChevronRight" }} onClick={this.click}>
             Run
-          </Button>
+          </DefaultButton>
         </HeroList>
       </div>
     );

--- a/src/taskpane/components/Progress.tsx
+++ b/src/taskpane/components/Progress.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Spinner, SpinnerType } from "office-ui-fabric-react";
+import { Spinner, SpinnerSize } from "@fluentui/react";
 
 export interface ProgressProps {
   logo: string;
@@ -15,7 +15,7 @@ export default class Progress extends React.Component<ProgressProps> {
       <section className="ms-welcome__progress ms-u-fadeIn500">
         <img width="90" height="90" src={logo} alt={title} title={title} />
         <h1 className="ms-fontSize-su ms-fontWeight-light ms-fontColor-neutralPrimary">{title}</h1>
-        <Spinner type={SpinnerType.large} label={message} />
+        <Spinner size={SpinnerSize.large} label={message} />
       </section>
     );
   }

--- a/src/taskpane/components/Project.App.tsx
+++ b/src/taskpane/components/Project.App.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Button, ButtonType } from "office-ui-fabric-react";
+import { DefaultButton } from "@fluentui/react";
 import Header from "./Header";
 import HeroList, { HeroListItem } from "./HeroList";
 import Progress from "./Progress";
@@ -92,14 +92,9 @@ export default class App extends React.Component<AppProps, AppState> {
           <p className="ms-font-l">
             Modify the source files, then click <b>Run</b>.
           </p>
-          <Button
-            className="ms-welcome__action"
-            buttonType={ButtonType.hero}
-            iconProps={{ iconName: "ChevronRight" }}
-            onClick={this.click}
-          >
+          <DefaultButton className="ms-welcome__action" iconProps={{ iconName: "ChevronRight" }} onClick={this.click}>
             Run
-          </Button>
+          </DefaultButton>
         </HeroList>
       </div>
     );

--- a/src/taskpane/components/Word.App.tsx
+++ b/src/taskpane/components/Word.App.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Button, ButtonType } from "office-ui-fabric-react";
+import { DefaultButton } from "@fluentui/react";
 import Header from "./Header";
 import HeroList, { HeroListItem } from "./HeroList";
 import Progress from "./Progress";
@@ -77,14 +77,9 @@ export default class App extends React.Component<AppProps, AppState> {
           <p className="ms-font-l">
             Modify the source files, then click <b>Run</b>.
           </p>
-          <Button
-            className="ms-welcome__action"
-            buttonType={ButtonType.hero}
-            iconProps={{ iconName: "ChevronRight" }}
-            onClick={this.click}
-          >
+          <DefaultButton className="ms-welcome__action" iconProps={{ iconName: "ChevronRight" }} onClick={this.click}>
             Run
-          </Button>
+          </DefaultButton>
         </HeroList>
       </div>
     );

--- a/src/taskpane/index.tsx
+++ b/src/taskpane/index.tsx
@@ -1,7 +1,7 @@
-import "office-ui-fabric-react/dist/css/fabric.min.css";
 import App from "./components/App";
 import { AppContainer } from "react-hot-loader";
-import { initializeIcons } from "office-ui-fabric-react/lib/Icons";
+import { initializeIcons } from "@fluentui/font-icons-mdl2";
+import { ThemeProvider } from "@fluentui/react";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 /* global document, Office, module, require */
@@ -15,7 +15,9 @@ const title = "Contoso Task Pane Add-in";
 const render = (Component) => {
   ReactDOM.render(
     <AppContainer>
-      <Component title={title} isOfficeInitialized={isOfficeInitialized} />
+      <ThemeProvider>
+        <Component title={title} isOfficeInitialized={isOfficeInitialized} />
+      </ThemeProvider>
     </AppContainer>,
     document.getElementById("container")
   );

--- a/src/taskpane/taskpane.html
+++ b/src/taskpane/taskpane.html
@@ -14,7 +14,7 @@
     <script type="text/javascript" src="https://appsforoffice.microsoft.com/lib/1.1/hosted/office.js"></script>
 
     <!-- For more information on Fluent UI, visit https://developer.microsoft.com/fluentui#/. -->
-    <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.6.1/css/fabric.min.css"/>
+    <link rel="stylesheet" href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/11.0.0/css/fabric.min.css" />
 
     <!-- Template styles -->
     <link href="taskpane.css" rel="stylesheet" type="text/css" />

--- a/test/src/test-taskpane.html
+++ b/test/src/test-taskpane.html
@@ -15,7 +15,7 @@
 
     <!-- For more information on Office UI Fabric, visit https://developer.microsoft.com/fabric. -->
     <link rel="stylesheet"
-        href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/9.6.1/css/fabric.min.css" />
+        href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/11.0.0/css/fabric.min.css" />
 
     <!-- Template styles -->
     <link href="taskpane.css" rel="stylesheet" type="text/css" />

--- a/test/src/test.app.tsx
+++ b/test/src/test.app.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, ButtonType } from 'office-ui-fabric-react';
+import { DefaultButton } from '@fluentui/react';
 import Header from '../../src/taskpane/components/Header';
 import HeroList, { HeroListItem } from '../../src/taskpane/components/HeroList';
 import Progress from '../../src/taskpane/components/Progress';
@@ -86,7 +86,7 @@ export default class App extends React.Component<AppProps, AppState> {
                 <Header logo='assets/logo-filled.png' title={this.props.title} message='Welcome' />
                 <HeroList message='Discover what Office Add-ins can do for you today!' items={this.state.listItems}>
                     <p className='ms-font-l'>Modify the source files, then click <b>Run</b>.</p>
-                    <Button className='ms-welcome__action' buttonType={ButtonType.hero} iconProps={{ iconName: 'ChevronRight' }} onClick={this.click}>Run</Button>
+                    <DefaultButton className='ms-welcome__action' iconProps={{ iconName: 'ChevronRight' }} onClick={this.click}>Run</DefaultButton>
                 </HeroList>
             </div>
         );

--- a/test/src/test.excel.app.tsx
+++ b/test/src/test.excel.app.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, ButtonType } from 'office-ui-fabric-react';
+import { DefaultButton } from '@fluentui/react';
 import Header from '../../src/taskpane/components/Header';
 import HeroList, { HeroListItem } from '../../src/taskpane/components/HeroList';
 import Progress from '../../src/taskpane/components/Progress';
@@ -100,7 +100,7 @@ export default class App extends React.Component<AppProps, AppState> {
                 <Header logo='assets/logo-filled.png' title={this.props.title} message='Welcome' />
                 <HeroList message='Discover what Office Add-ins can do for you today!' items={this.state.listItems}>
                     <p className='ms-font-l'>Modify the source files, then click <b>Run</b>.</p>
-                    <Button className='ms-welcome__action' buttonType={ButtonType.hero} iconProps={{ iconName: 'ChevronRight' }} >Run</Button>
+                    <DefaultButton className='ms-welcome__action' iconProps={{ iconName: 'ChevronRight' }} >Run</DefaultButton>
                 </HeroList>
             </div>
         );

--- a/test/src/test.index.tsx
+++ b/test/src/test.index.tsx
@@ -1,7 +1,6 @@
-import 'office-ui-fabric-react/dist/css/fabric.min.css';
 import App from './test.app'
 import { AppContainer } from 'react-hot-loader';
-import { initializeIcons } from 'office-ui-fabric-react/lib/Icons';
+import { initializeIcons } from '@fluentui/font-icons-mdl2';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 

--- a/test/src/test.powerpoint.app.tsx
+++ b/test/src/test.powerpoint.app.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, ButtonType } from 'office-ui-fabric-react';
+import { DefaultButton } from '@fluentui/react';
 import Header from '../../src/taskpane/components/Header';
 import HeroList, { HeroListItem } from '../../src/taskpane/components/HeroList';
 import Progress from '../../src/taskpane/components/Progress';
@@ -108,7 +108,7 @@ export default class App extends React.Component<AppProps, AppState> {
                 <Header logo='assets/logo-filled.png' title={this.props.title} message='Welcome' />
                 <HeroList message='Discover what Office Add-ins can do for you today!' items={this.state.listItems}>
                     <p className='ms-font-l'>Modify the source files, then click <b>Run</b>.</p>
-                    <Button className='ms-welcome__action' buttonType={ButtonType.hero} iconProps={{ iconName: 'ChevronRight' }} >Run</Button>
+                    <DefaultButton className='ms-welcome__action' iconProps={{ iconName: 'ChevronRight' }} >Run</DefaultButton>
                 </HeroList>
             </div>
         );

--- a/test/src/test.word.app.tsx
+++ b/test/src/test.word.app.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, ButtonType } from 'office-ui-fabric-react';
+import { DefaultButton } from '@fluentui/react';
 import Header from '../../src/taskpane/components/Header';
 import HeroList, { HeroListItem } from '../../src/taskpane/components/HeroList';
 import Progress from '../../src/taskpane/components/Progress';
@@ -98,7 +98,7 @@ export default class App extends React.Component<AppProps, AppState> {
                 <Header logo='assets/logo-filled.png' title={this.props.title} message='Welcome' />
                 <HeroList message='Discover what Office Add-ins can do for you today!' items={this.state.listItems}>
                     <p className='ms-font-l'>Modify the source files, then click <b>Run</b>.</p>
-                    <Button className='ms-welcome__action' buttonType={ButtonType.hero} iconProps={{ iconName: 'ChevronRight' }} >Run</Button>
+                    <DefaultButton className='ms-welcome__action' iconProps={{ iconName: 'ChevronRight' }} >Run</DefaultButton>
                 </HeroList>
             </div>
         );

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = async (env, options) => {
                 'react',
                 'react-dom',
                 'core-js',
-                'office-ui-fabric-react'
+                '@fluentui/react'
             ],
             taskpane: [
                 'react-hot-loader/patch',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = async (env, options)  => {
         'react',
         'react-dom',
         'core-js',
-        'office-ui-fabric-react'
+        '@fluentui/react'
     ],
     taskpane: [
         'react-hot-loader/patch',


### PR DESCRIPTION
This PR switches out the deprecated `office-ui-fabric-react` for `@fluentui/react` v8.

This PR still uses `office-ui-fabric-core` for styling. (Albeit a bumped version)
Do we want to migrate everything to CSS-in-JS and use `Text` components as well?

Fixes https://github.com/OfficeDev/generator-office/issues/616, https://github.com/OfficeDev/generator-office/issues/638