### PR TITLE
Add children declaration to remove eventual linting error

### DIFF
--- a/src/taskpane/components/HeroList.tsx
+++ b/src/taskpane/components/HeroList.tsx
@@ -8,6 +8,7 @@ export interface HeroListItem {
 export interface HeroListProps {
   message: string;
   items: HeroListItem[];
+  children: any;
 }
 
 export default class HeroList extends React.Component<HeroListProps> {


### PR DESCRIPTION
Resolves https://github.com/OfficeDev/generator-office/issues/730. Following instructions provided by @millerds there.

Thank you for your pull request!  Please provide the following information.

---

**Change Description**:

    When generating the TaskPane React TS app, `npm run lint` fails out of the box due to a missing `children` on the props interface. This allows for linting to be successful.

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
    If Yes, briefly describe what is impacted.

No

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
    If Yes, briefly describe what is impacted.

No

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
    If Yes, briefly describe what is impacted.

Yes - A `children: any;` property is added to the `HeroListProps` interface.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    If Yes, briefly describe what is impacted.

No

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

CC @Rick-Kirkham / @millerds. 

**Validation/testing performed**:

⚠️ None at this point; this was a prescribed change that was recommended elsewhere. I'm happy to follow a process to test but might need a little guidance as this is a quick change and I haven't engaged with this repo before.
