### PR TITLE
Correct the webpack polyfill entry reference

### DIFF
--- a/src/taskpane/components/HeroList.tsx
+++ b/src/taskpane/components/HeroList.tsx
@@ -22,11 +22,11 @@ export default class HeroList extends React.Component<HeroListProps> {
       </li>
     ));
     return (
-      <main className="ms-welcome__main">
+      <div className="ms-welcome__main">
         <h2 className="ms-font-xl ms-fontWeight-semilight ms-fontColor-neutralPrimary ms-u-slideUpIn20">{message}</h2>
         <ul className="ms-List ms-welcome__features ms-u-slideUpIn10">{listItems}</ul>
         {children}
-      </main>
+      </div>
     );
   }
 }

--- a/test/end-to-end/webpack.config.js
+++ b/test/end-to-end/webpack.config.js
@@ -71,7 +71,7 @@ module.exports = async (env, options) => {
       new HtmlWebpackPlugin({
         filename: "taskpane.html",
         template: path.resolve(__dirname, "./src/test-taskpane.html"),
-        chunks: ["taskpane", "vendor", "polyfills"],
+        chunks: ["polyfill", "vendor", "taskpane"],
       }),
       new CopyWebpackPlugin({
         patterns: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,7 +83,7 @@ module.exports = async (env, options) => {
       new HtmlWebpackPlugin({
         filename: "taskpane.html",
         template: "./src/taskpane/taskpane.html",
-        chunks: ["taskpane", "vendor", "polyfills"],
+        chunks: ["polyfill", "vendor", "taskpane"],
       }),
       new HtmlWebpackPlugin({
         filename: "commands.html",


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:
A misspelling was causing the polyfill generation to be incorrect and projects wouldn't work with the IE webview as a result.  Corrected the reference to the entries in webpack config and the adjusted a component compatibility problem that was hidden behind that lack of polyfills

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
No.

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
No.

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
No.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Tried resulting changes on a machine running an older version of office that uses the IE webview explicitly.