### PR TITLE
Fix: Handle case sensitivity for host files

### DIFF
--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -36,6 +36,16 @@ const readFileAsync = util.promisify(fs.readFile);
 const unlinkFileAsync = util.promisify(fs.unlink);
 const writeFileAsync = util.promisify(fs.writeFile);
 
+async function unlinkFileSafeAsync(path) {
+  try {
+    await unlinkFileAsync(path)
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}
+
 async function modifyProjectForSingleHost(host) {
   if (!host) {
     throw new Error("The host was not provided.");
@@ -60,8 +70,8 @@ async function convertProjectToSingleHost(host) {
 
   // Delete all host-specific files
   hosts.forEach(async function (host) {
-    await unlinkFileAsync(`./manifest.${host}.xml`);
-    await unlinkFileAsync(`./src/taskpane/${getHostName(host)}.ts`);
+    await unlinkFileSafeAsync(`./manifest.${host}.xml`);
+    await unlinkFileSafeAsync(`./src/taskpane/${getHostName(host)}.ts`);
   });
 
   // Delete test folder
@@ -128,17 +138,17 @@ async function updateLaunchJsonFile(host) {
 function getHostName(host) {
   switch (host) {
     case "excel":
-      return "Excel";
+      return "excel";
     case "onenote":
-      return "OneNote";
+      return "onenote";
     case "outlook":
-      return "Outlook";
+      return "outlook";
     case "powerpoint":
-      return "PowerPoint";
+      return "powerpoint";
     case "project":
-      return "Project";
+      return "project";
     case "word":
-      return "Word";
+      return "word";
     default:
       throw new Error(`'${host}' is not a supported host.`);
   }
@@ -164,23 +174,23 @@ function deleteFolder(folder) {
 }
 
 async function deleteSupportFiles() {
-  await unlinkFileAsync("CONTRIBUTING.md");
-  await unlinkFileAsync("LICENSE");
-  await unlinkFileAsync("README.md");
-  await unlinkFileAsync("SECURITY.md");
-  await unlinkFileAsync("./convertToSingleHost.js");
-  await unlinkFileAsync(".npmrc");
-  await unlinkFileAsync("package-lock.json");
+  await unlinkFileSafeAsync("CONTRIBUTING.md");
+  await unlinkFileSafeAsync("LICENSE");
+  await unlinkFileSafeAsync("README.md");
+  await unlinkFileSafeAsync("SECURITY.md");
+  await unlinkFileSafeAsync("./convertToSingleHost.js");
+  await unlinkFileSafeAsync(".npmrc");
+  await unlinkFileSafeAsync("package-lock.json");
 }
 
 async function deleteJSONManifestRelatedFiles() {
-  await unlinkFileAsync("manifest.json");
-  await unlinkFileAsync("assets/color.png");
-  await unlinkFileAsync("assets/outline.png");
+  await unlinkFileSafeAsync("manifest.json");
+  await unlinkFileSafeAsync("assets/color.png");
+  await unlinkFileSafeAsync("assets/outline.png");
 }
 
 async function deleteXMLManifestRelatedFiles() {
-  await unlinkFileAsync("manifest.xml");
+  await unlinkFileSafeAsync("manifest.xml");
 }
 
 async function updatePackageJsonForXMLManifest() {

--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -136,22 +136,11 @@ async function updateLaunchJsonFile(host) {
 }
 
 function getHostName(host) {
-  switch (host) {
-    case "excel":
-      return "excel";
-    case "onenote":
-      return "onenote";
-    case "outlook":
-      return "outlook";
-    case "powerpoint":
-      return "powerpoint";
-    case "project":
-      return "project";
-    case "word":
-      return "word";
-    default:
-      throw new Error(`'${host}' is not a supported host.`);
+  if (!hosts.includes(host)) {
+    throw new Error(`'${host}' is not a supported host.`);
   }
+
+  return host;
 }
 
 function deleteFolder(folder) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d16466a5-a85b-4b4e-9092-67f10c70ac25)


Environment:

- Ubuntu 24.04.2 LTS

Fix: Handle case sensitivity for host files

The problem was caused because hosts were provided in uppercase, which prevented the script from finding the correct taskpane files in their directories.

The getHostName function was modified to properly validate supported hosts by ensuring they exactly match the names of the components

The unlinkFileAsync function was encapsulated into a new unlinkFileSafeAsync function to safely delete files without throwing errors when files do not exist (handles ENOENT).

Do these changes impact any npm scripts commands (in package.json)?
No, there is no impact on npm scripts.

Do these changes impact VS Code debugging options (launch.json)?
No, there is no impact on VS Code debugging options.

Do these changes impact template output?
Yes, this affects file handling by ensuring that host-specific taskpane files and manifests are correctly found and deleted safely if missing.

Do these changes impact documentation?
No documentation changes are required.

Validation/testing performed:

Manually tested with various host inputs in uppercase and lowercase to confirm the host validation works correctly.

Verified that the script no longer throws errors when attempting to delete files that do not exist.


@microsoft-github-policy-service agree
